### PR TITLE
Remove additional substraction of 'amount' in Change Output value

### DIFF
--- a/packages/lasereyes-core/src/lib/helpers.ts
+++ b/packages/lasereyes-core/src/lib/helpers.ts
@@ -201,7 +201,7 @@ export async function createSendBtcPsbt(
   if (amountGathered > satsNeeded) {
     psbt.addOutput({
       address: paymentAddress,
-      value: BigInt(amountGathered - satsNeeded - amount),
+      value: BigInt(amountGathered - satsNeeded),
     })
   }
 


### PR DESCRIPTION
[Ref pull req from omnisat/lasereyes](https://github.com/omnisat/lasereyes/pull/53)

Removed the extra amount substraction from the change output value calculation, as amount is already included as part of satsNeeded, leading to negative numbers, or the sender not getting back the change they are supposed to.