### PR TITLE
Feature: Add _forceReconnect arg to connect() to bypass Xverse flow

### DIFF
--- a/packages/lasereyes-core/src/client/index.ts
+++ b/packages/lasereyes-core/src/client/index.ts
@@ -153,7 +153,7 @@ export class LaserEyesClient {
     }
   }
 
-  async connect(defaultWallet: ProviderType) {
+  async connect(defaultWallet: ProviderType, _forceReconnect?: boolean) {
     if (this.disposed) {
       console.warn('Client disposed, cannot connect')
       return
@@ -166,7 +166,7 @@ export class LaserEyesClient {
         throw new Error('Unsupported wallet provider')
       }
       const provider = this.$providerMap[defaultWallet]
-      await provider?.connect(defaultWallet)
+      await provider?.connect(defaultWallet, _forceReconnect ?? false)
       this.$store.setKey('connected', true)
       this.$store.setKey('provider', defaultWallet)
     } catch (error) {

--- a/packages/lasereyes-core/src/client/providers/index.ts
+++ b/packages/lasereyes-core/src/client/providers/index.ts
@@ -65,7 +65,7 @@ export abstract class WalletProvider {
 
   abstract dispose(): void
 
-  abstract connect(defaultWallet: ProviderType): Promise<void>
+  abstract connect(defaultWallet: ProviderType, _forceReconnect?: boolean): Promise<void>
 
   async requestAccounts(): Promise<string[]> {
     return this.$store.get().accounts

--- a/packages/lasereyes-core/src/client/providers/leather.ts
+++ b/packages/lasereyes-core/src/client/providers/leather.ts
@@ -130,7 +130,7 @@ export default class LeatherProvider extends WalletProvider {
     this.observer?.disconnect()
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     const { address, paymentAddress } = this.$valueStore!.get()
 
     if (address) {

--- a/packages/lasereyes-core/src/client/providers/magic-eden.ts
+++ b/packages/lasereyes-core/src/client/providers/magic-eden.ts
@@ -145,7 +145,7 @@ export default class MagicEdenProvider extends WalletProvider {
     this.observer?.disconnect()
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     const { address, paymentAddress } = this.$valueStore!.get()
 
     try {

--- a/packages/lasereyes-core/src/client/providers/okx.ts
+++ b/packages/lasereyes-core/src/client/providers/okx.ts
@@ -140,7 +140,7 @@ export default class OkxProvider extends WalletProvider {
     this.observer?.disconnect()
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     const { address, paymentAddress } = this.$valueStore!.get()
 
     if (address) {

--- a/packages/lasereyes-core/src/client/providers/op-net.ts
+++ b/packages/lasereyes-core/src/client/providers/op-net.ts
@@ -102,7 +102,7 @@ export default class OpNetProvider extends WalletProvider {
     this.parent.connect(OP_NET)
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     if (!this.library) throw new Error("OP_NET isn't installed")
     const opNetAccounts = await this.library.requestAccounts()
     if (!opNetAccounts) throw new Error('No accounts found')

--- a/packages/lasereyes-core/src/client/providers/orange.ts
+++ b/packages/lasereyes-core/src/client/providers/orange.ts
@@ -142,7 +142,7 @@ export default class OrangeProvider extends WalletProvider {
     this.observer?.disconnect()
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     const { address, paymentAddress } = this.$valueStore!.get()
     try {
       if (address) {

--- a/packages/lasereyes-core/src/client/providers/oyl.ts
+++ b/packages/lasereyes-core/src/client/providers/oyl.ts
@@ -113,7 +113,7 @@ export default class OylProvider extends WalletProvider {
     this.observer?.disconnect()
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     const { address, paymentAddress } = this.$valueStore!.get()
 
     if (address) {

--- a/packages/lasereyes-core/src/client/providers/phantom.ts
+++ b/packages/lasereyes-core/src/client/providers/phantom.ts
@@ -88,7 +88,7 @@ export default class PhantomProvider extends WalletProvider {
     }
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect?: boolean): Promise<void> {
     if (!this.library) throw new Error("Phantom isn't installed")
     if (isTestnetNetwork(this.network)) {
       throw new Error(`${this.network} is not supported by ${PHANTOM}`)

--- a/packages/lasereyes-core/src/client/providers/sparrow.ts
+++ b/packages/lasereyes-core/src/client/providers/sparrow.ts
@@ -112,7 +112,7 @@ export default class SparrowProvider extends WalletProvider {
     this.observer?.disconnect()
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     try {
       const { address: foundAddress, paymentAddress: foundPaymentAddress } =
         this.$valueStore!.get()

--- a/packages/lasereyes-core/src/client/providers/unisat.ts
+++ b/packages/lasereyes-core/src/client/providers/unisat.ts
@@ -111,7 +111,7 @@ export default class UnisatProvider extends WalletProvider {
     this.parent.connect(UNISAT)
   }
 
-  async connect(_: ProviderType): Promise<void> {
+  async connect(_: ProviderType, _forceReconnect = false): Promise<void> {
     if (!this.library) throw new Error("Unisat isn't installed")
     const unisatAccounts = await this.library.requestAccounts()
     if (!unisatAccounts) throw new Error('No accounts found')

--- a/packages/lasereyes-react/lib/providers/lasereyes-provider.tsx
+++ b/packages/lasereyes-react/lib/providers/lasereyes-provider.tsx
@@ -39,7 +39,8 @@ export default function LaserEyesProvider({
   }, [clientConfig, clientStores])
 
   const connect = useCallback(
-    async (defaultWallet: ProviderType) => await client?.connect(defaultWallet),
+    async (defaultWallet: ProviderType, _forceReconnect?: boolean) =>
+      await client?.connect(defaultWallet, _forceReconnect),
     [client]
   )
   const disconnect = useCallback(() => client?.disconnect(), [client])

--- a/packages/lasereyes-react/lib/providers/types.ts
+++ b/packages/lasereyes-react/lib/providers/types.ts
@@ -35,7 +35,7 @@ export type LaserEyesContextType = {
   hasPhantom: boolean
   hasWizz: boolean
 
-  connect: (walletName: ProviderType) => Promise<void>
+  connect: (walletName: ProviderType, _forceReconnect?: boolean) => Promise<void>
   disconnect: () => void
   requestAccounts: () => Promise<string[]>
   getNetwork: () => Promise<string | undefined>


### PR DESCRIPTION
Addresses #393. This adds an optional `_forceReconnect` arg to `connect()` which, if true, bypasses the auto-connect functionality that was introduced to the Xverse provider in PR #310 . In other words, it forces the Xverse window to pop up when you call connect() instead of checking if there is already an account connected via `request(wallet_getAccount)`.


This lets someone do "switch account" functionality with something like:
```
const switchAccounts = async () => {
disconnect();
await connect(true)
```

**Note:** From what I could tell, the Xverse provider is the only one for which `_forceReconnect` would be meaningful, but I wasn't totally sure. And I of course needed to add the argument to all the providers' `connect` methods for type checking reasons. 
