### PR TITLE
fix: unisat network issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules
 .env.development.local
 .env.test.local
 .env.production.local
-
+*.timestamp-*.mjs
 # Testing
 coverage
 

--- a/packages/lasereyes-core/src/client/providers/unisat.ts
+++ b/packages/lasereyes-core/src/client/providers/unisat.ts
@@ -115,11 +115,7 @@ export default class UnisatProvider extends WalletProvider {
     if (!this.library) throw new Error("Unisat isn't installed")
     const unisatAccounts = await this.library.requestAccounts()
     if (!unisatAccounts) throw new Error('No accounts found')
-    await this.getNetwork().then((network) => {
-      if (this.network !== network) {
-        this.switchNetwork(this.network)
-      }
-    })
+
     const unisatPubKey = await this.library.getPublicKey()
     if (!unisatPubKey) throw new Error('No public key found')
     this.$store.setKey('accounts', unisatAccounts)


### PR DESCRIPTION
The issue:
If the network "TESTNET" is passed in and you use unisat, on every subsequent autoconnect when the page reloads Laser eyes tries a roundtrip of network change request

The fix:
https://github.com/omnisat/lasereyes-mono/blob/236b4e0bc99cb9a9912a874aac87b40dab5ee2fa/packages/lasereyes-core/src/client/providers/unisat.ts#L118 

This seems to be unintentional, because the super class already handles network changes on connections. XVerse provider doesnt try to change the network on connect (in its implementation of super) and therefore it works fine. 

This wouldnt be an issue but since the $network store is set AFTER the super class calls .connect(), the unisats connect() sees "mainnet" in $network, even if the config is set to use "testnet" - and triggers the unecessary chain of network change prompts. Removing this network switch functionality from unisats connect method fixes the issue.
