### PR TITLE
Support `signPsbts`

### DIFF
--- a/packages/lasereyes-core/src/client/index.ts
+++ b/packages/lasereyes-core/src/client/index.ts
@@ -403,45 +403,21 @@ export class LaserEyesClient {
   async signPsbts(
     options: LaserEyesSignPsbtsOptions
   ): Promise<SignPsbtsResponse> {
-    const { psbts, finalize = false, broadcast = false } = options
+    const { psbts, finalize = false, broadcast = false, inputsToSign } = options
 
     if (!psbts || psbts.length === 0) {
       throw new Error('No PSBTs provided')
     }
-
-    // Process each PSBT to get hex and base64 versions
-    const processedPsbts = psbts.map(({ tx, inputsToSign }) => {
-      let psbtHex: string
-      let psbtBase64: string
-
-      if (!tx) throw new Error('No PSBT provided')
-
-      if (isHex(tx)) {
-        psbtBase64 = bitcoin.Psbt.fromHex(tx).toBase64()
-        psbtHex = tx
-      } else if (isBase64(tx)) {
-        psbtBase64 = tx
-        psbtHex = bitcoin.Psbt.fromBase64(tx).toHex()
-      } else {
-        throw new Error('Invalid PSBT format')
-      }
-
-      return {
-        tx,
-        psbtHex,
-        psbtBase64,
-        inputsToSign,
-      }
-    })
 
     const provider = this.$store.get().provider
 
     if (provider && this.$providerMap[provider]) {
       try {
         const result = await this.$providerMap[provider]?.signPsbts({
-          psbts: processedPsbts,
+          psbts,
           finalize,
           broadcast,
+          inputsToSign,
         })
         return result
       } catch (error) {

--- a/packages/lasereyes-core/src/client/index.ts
+++ b/packages/lasereyes-core/src/client/index.ts
@@ -37,9 +37,11 @@ import { isBase64, isHex } from '../lib/utils'
 import * as bitcoin from 'bitcoinjs-lib'
 import type {
   LaserEyesSignPsbtOptions,
+  LaserEyesSignPsbtsOptions,
   LaserEyesStoreType,
   SignMessageOptions,
   SignPsbtResponse,
+  SignPsbtsResponse,
 } from './types'
 import { triggerDOMShakeHack } from './utils'
 import XVerseProvider from './providers/xverse'
@@ -398,6 +400,65 @@ export class LaserEyesClient {
     }
   }
 
+  async signPsbts(
+    options: LaserEyesSignPsbtsOptions
+  ): Promise<SignPsbtsResponse> {
+    const { psbts, finalize = false, broadcast = false } = options
+
+    if (!psbts || psbts.length === 0) {
+      throw new Error('No PSBTs provided')
+    }
+
+    // Process each PSBT to get hex and base64 versions
+    const processedPsbts = psbts.map(({ tx, inputsToSign }) => {
+      let psbtHex: string
+      let psbtBase64: string
+
+      if (!tx) throw new Error('No PSBT provided')
+
+      if (isHex(tx)) {
+        psbtBase64 = bitcoin.Psbt.fromHex(tx).toBase64()
+        psbtHex = tx
+      } else if (isBase64(tx)) {
+        psbtBase64 = tx
+        psbtHex = bitcoin.Psbt.fromBase64(tx).toHex()
+      } else {
+        throw new Error('Invalid PSBT format')
+      }
+
+      return {
+        tx,
+        psbtHex,
+        psbtBase64,
+        inputsToSign,
+      }
+    })
+
+    const provider = this.$store.get().provider
+
+    if (provider && this.$providerMap[provider]) {
+      try {
+        const result = await this.$providerMap[provider]?.signPsbts({
+          psbts: processedPsbts,
+          finalize,
+          broadcast,
+        })
+        return result
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message.toLowerCase().includes('not implemented')) {
+            throw new Error(
+              "The connected wallet doesn't support PSBT signing..."
+            )
+          }
+        }
+        throw error
+      }
+    } else {
+      throw new Error('No wallet provider connected')
+    }
+  }
+
   async pushPsbt(tx: string) {
     const provider = this.$store.get().provider
     if (!provider) return
@@ -441,12 +502,12 @@ export class LaserEyesClient {
     sendArgs: T extends typeof BTC
       ? BTCSendArgs
       : T extends typeof RUNES
-      ? RuneSendArgs
-      : T extends typeof BRC20
-      ? Brc20SendArgs
-      : T extends typeof ALKANES
-      ? AlkaneSendArgs
-      : never
+        ? RuneSendArgs
+        : T extends typeof BRC20
+          ? Brc20SendArgs
+          : T extends typeof ALKANES
+            ? AlkaneSendArgs
+            : never
   ): Promise<string | undefined> {
     const provider = this.$store.get().provider
     if (!provider) return

--- a/packages/lasereyes-core/src/client/providers/index.ts
+++ b/packages/lasereyes-core/src/client/providers/index.ts
@@ -19,7 +19,6 @@ import type {
 import type { LaserEyesClient } from '..'
 import { inscribeContent } from '../../lib/inscribe'
 import { broadcastTx } from '../../lib/helpers'
-import { isBase64, isHex } from '../../lib/utils'
 import * as bitcoin from 'bitcoinjs-lib'
 import {
   FRACTAL_TESTNET,

--- a/packages/lasereyes-core/src/client/providers/index.ts
+++ b/packages/lasereyes-core/src/client/providers/index.ts
@@ -184,44 +184,9 @@ export abstract class WalletProvider {
   >
 
   async signPsbts(
-    signPsbtsOptions: WalletProviderSignPsbtsOptions
+    _signPsbtsOptions: WalletProviderSignPsbtsOptions
   ): Promise<SignPsbtsResponse> {
-    const { psbts, finalize, broadcast, inputsToSign } = signPsbtsOptions
-
-    const results = []
-    for (const psbtString of psbts) {
-      let psbtHex: string
-      let psbtBase64: string
-
-      if (isHex(psbtString)) {
-        psbtBase64 = bitcoin.Psbt.fromHex(psbtString).toBase64()
-        psbtHex = psbtString
-      } else if (isBase64(psbtString)) {
-        psbtBase64 = psbtString
-        psbtHex = bitcoin.Psbt.fromBase64(psbtString).toHex()
-      } else {
-        throw new Error('Invalid PSBT format')
-      }
-
-      const result = await this.signPsbt({
-        tx: psbtString,
-        psbtHex,
-        psbtBase64,
-        finalize,
-        broadcast,
-        inputsToSign,
-        network: signPsbtsOptions.network,
-      })
-      results.push(result)
-    }
-
-    return {
-      signedPsbts: results.filter(Boolean) as {
-        signedPsbtHex: string | undefined
-        signedPsbtBase64: string | undefined
-        txId?: string | undefined
-      }[],
-    }
+    throw UNSUPPORTED_PROVIDER_METHOD_ERROR
   }
 
   async pushPsbt(_tx: string): Promise<string | undefined> {

--- a/packages/lasereyes-core/src/client/providers/index.ts
+++ b/packages/lasereyes-core/src/client/providers/index.ts
@@ -2,6 +2,8 @@ import type { MapStore, WritableAtom } from 'nanostores'
 import type {
   LaserEyesStoreType,
   WalletProviderSignPsbtOptions,
+  WalletProviderSignPsbtsOptions,
+  SignPsbtsResponse,
 } from '../types'
 import type {
   Brc20SendArgs,
@@ -179,6 +181,34 @@ export abstract class WalletProvider {
       }
     | undefined
   >
+
+  async signPsbts(
+    signPsbtsOptions: WalletProviderSignPsbtsOptions
+  ): Promise<SignPsbtsResponse> {
+    const { psbts, finalize, broadcast } = signPsbtsOptions
+
+    const results = []
+    for (const psbt of psbts) {
+      const result = await this.signPsbt({
+        tx: psbt.tx,
+        psbtHex: psbt.psbtHex,
+        psbtBase64: psbt.psbtBase64,
+        finalize,
+        broadcast,
+        inputsToSign: psbt.inputsToSign,
+        network: signPsbtsOptions.network,
+      })
+      results.push(result)
+    }
+
+    return {
+      signedPsbts: results.filter(Boolean) as {
+        signedPsbtHex: string | undefined
+        signedPsbtBase64: string | undefined
+        txId?: string | undefined
+      }[],
+    }
+  }
 
   async pushPsbt(_tx: string): Promise<string | undefined> {
     let payload = _tx

--- a/packages/lasereyes-core/src/client/providers/oyl.ts
+++ b/packages/lasereyes-core/src/client/providers/oyl.ts
@@ -192,17 +192,18 @@ export default class OylProvider extends WalletProvider {
   ): Promise<SignPsbtsResponse> {
     const { psbts, finalize, broadcast } = signPsbtsOptions
 
-    const psbtHexArray = psbts.map((p) => p.psbtHex)
-    const result = await this.library.signPsbts({
-      psbts: psbtHexArray,
+    const psbtsToSign = psbts.map((p) => ({
+      psbt: p,
       finalize,
       broadcast,
-    })
+    }))
+
+    const result = await this.library.signPsbts(psbtsToSign)
 
     // Handle the response format from OYL
     const signedPsbts =
-      result.psbts?.map((psbtHex: string, index: number) => {
-        const psbtObj = bitcoin.Psbt.fromHex(psbtHex)
+      result.map((data: { psbt: string }, index: number) => {
+        const psbtObj = bitcoin.Psbt.fromHex(data.psbt)
         return {
           signedPsbtHex: psbtObj.toHex(),
           signedPsbtBase64: psbtObj.toBase64(),

--- a/packages/lasereyes-core/src/client/providers/unisat.ts
+++ b/packages/lasereyes-core/src/client/providers/unisat.ts
@@ -8,6 +8,8 @@ import {
   LaserEyesStoreType,
   SignMessageOptions,
   WalletProviderSignPsbtOptions,
+  WalletProviderSignPsbtsOptions,
+  SignPsbtsResponse,
 } from '../types'
 import { BIP322, BIP322_SIMPLE } from '../../constants'
 import { LaserEyesClient } from '..'
@@ -188,6 +190,42 @@ export default class UnisatProvider extends WalletProvider {
       signedPsbtBase64: psbtSignedPsbt.toBase64(),
       txId: undefined,
     }
+  }
+
+  async signPsbts(
+    signPsbtsOptions: WalletProviderSignPsbtsOptions
+  ): Promise<SignPsbtsResponse> {
+    const { psbts, finalize, broadcast } = signPsbtsOptions
+
+    const psbtHexArray = psbts.map((p) => p.psbtHex)
+    const toSignInputsArray = psbts.map((p) => p.inputsToSign)
+
+    const signedPsbts = await this.library.signPsbts(
+      psbtHexArray,
+      omitUndefined({
+        autoFinalized: finalize,
+        toSignInputs: toSignInputsArray,
+      })
+    )
+
+    const results = await Promise.all(
+      signedPsbts.map(async (signedPsbtHex: string) => {
+        const psbtObj = bitcoin.Psbt.fromHex(signedPsbtHex)
+
+        let txId: string | undefined
+        if (finalize && broadcast) {
+          txId = await this.pushPsbt(signedPsbtHex)
+        }
+
+        return {
+          signedPsbtHex: psbtObj.toHex(),
+          signedPsbtBase64: psbtObj.toBase64(),
+          txId,
+        }
+      })
+    )
+
+    return { signedPsbts: results }
   }
 
   async getPublicKey() {

--- a/packages/lasereyes-core/src/client/providers/unisat.ts
+++ b/packages/lasereyes-core/src/client/providers/unisat.ts
@@ -195,16 +195,13 @@ export default class UnisatProvider extends WalletProvider {
   async signPsbts(
     signPsbtsOptions: WalletProviderSignPsbtsOptions
   ): Promise<SignPsbtsResponse> {
-    const { psbts, finalize, broadcast } = signPsbtsOptions
-
-    const psbtHexArray = psbts.map((p) => p.psbtHex)
-    const toSignInputsArray = psbts.map((p) => p.inputsToSign)
+    const { psbts, finalize, broadcast, inputsToSign } = signPsbtsOptions
 
     const signedPsbts = await this.library.signPsbts(
-      psbtHexArray,
+      psbts,
       omitUndefined({
         autoFinalized: finalize,
-        toSignInputs: toSignInputsArray,
+        toSignInputs: inputsToSign,
       })
     )
 

--- a/packages/lasereyes-core/src/client/types.ts
+++ b/packages/lasereyes-core/src/client/types.ts
@@ -43,9 +43,10 @@ export type LaserEyesSignPsbtOptions = {
 }
 
 export type LaserEyesSignPsbtsOptions = {
-  psbts: { tx: string; inputsToSign?: InputToSign[] }[]
+  psbts: string[]
   finalize?: boolean
   broadcast?: boolean
+  inputsToSign?: InputToSign[]
 }
 
 export type InputToSign = {
@@ -64,14 +65,10 @@ export type WalletProviderSignPsbtOptions = {
 }
 
 export type WalletProviderSignPsbtsOptions = {
-  psbts: {
-    tx: string
-    psbtHex: string
-    psbtBase64: string
-    inputsToSign?: InputToSign[]
-  }[]
+  psbts: string[]
   finalize?: boolean
   broadcast?: boolean
+  inputsToSign?: InputToSign[]
   network?: NetworkType
 }
 

--- a/packages/lasereyes-core/src/client/types.ts
+++ b/packages/lasereyes-core/src/client/types.ts
@@ -21,7 +21,11 @@ export interface SparrowWalletProvider {
   requestAccounts(network?: NetworkType): Promise<string[]>
   getPublicKey(network?: NetworkType): Promise<string>
   getNetwork(): Promise<NetworkType>
-  switchNetwork(network: NetworkType): Promise<void | { address: string; paymentAddress: string; publicKey: string }>
+  switchNetwork(network: NetworkType): Promise<void | {
+    address: string
+    paymentAddress: string
+    publicKey: string
+  }>
   signMessage(message: string): Promise<string>
   signPsbt(psbtBase64: string): Promise<string>
 }
@@ -36,6 +40,12 @@ export type LaserEyesSignPsbtOptions = {
   finalize?: boolean
   broadcast?: boolean
   inputsToSign?: InputToSign[]
+}
+
+export type LaserEyesSignPsbtsOptions = {
+  psbts: { tx: string; inputsToSign?: InputToSign[] }[]
+  finalize?: boolean
+  broadcast?: boolean
 }
 
 export type InputToSign = {
@@ -53,10 +63,32 @@ export type WalletProviderSignPsbtOptions = {
   network?: NetworkType
 }
 
+export type WalletProviderSignPsbtsOptions = {
+  psbts: {
+    tx: string
+    psbtHex: string
+    psbtBase64: string
+    inputsToSign?: InputToSign[]
+  }[]
+  finalize?: boolean
+  broadcast?: boolean
+  network?: NetworkType
+}
+
 export type SignPsbtResponse =
   | {
       signedPsbtHex: string | undefined
       signedPsbtBase64: string | undefined
       txId?: string | undefined
+    }
+  | undefined
+
+export type SignPsbtsResponse =
+  | {
+      signedPsbts: {
+        signedPsbtHex: string | undefined
+        signedPsbtBase64: string | undefined
+        txId?: string | undefined
+      }[]
     }
   | undefined

--- a/packages/lasereyes-react/src/providers/context.ts
+++ b/packages/lasereyes-react/src/providers/context.ts
@@ -10,8 +10,8 @@ import { MapStore, WritableAtom } from 'nanostores'
 
 const { $store, $network } = createStores()
 export const defaultMethods = {
-  connect: async () => { },
-  disconnect: () => { },
+  connect: async () => {},
+  disconnect: () => {},
   getBalance: async () => '',
   getMetaBalances: async () => [],
   getInscriptions: async () => [],
@@ -25,10 +25,13 @@ export const defaultMethods = {
     signedPsbtBase64: '',
     signedPsbtHex: '',
   }),
-  switchNetwork: async () => { },
+  signPsbts: async () => ({
+    signedPsbts: [],
+  }),
+  switchNetwork: async () => {},
   inscribe: async () => '',
   send: async () => '',
-  sendInscriptions: async () => "",
+  sendInscriptions: async () => '',
   getUtxos: async () => [],
 }
 export const LaserEyesStoreContext = createContext<{
@@ -39,6 +42,7 @@ export const LaserEyesStoreContext = createContext<{
     LaserEyesContextType,
     | 'switchNetwork'
     | 'signPsbt'
+    | 'signPsbts'
     | 'signMessage'
     | 'requestAccounts'
     | 'sendBTC'

--- a/packages/lasereyes-react/src/providers/lasereyes-provider.tsx
+++ b/packages/lasereyes-react/src/providers/lasereyes-provider.tsx
@@ -14,10 +14,12 @@ import {
   createStores,
   LaserEyesClient,
   type LaserEyesSignPsbtOptions,
+  type LaserEyesSignPsbtsOptions,
   type NetworkType,
   type Protocol,
   type ProviderType,
   type SignMessageOptions,
+  type SignPsbtsResponse,
 } from '@omnisat/lasereyes-core'
 
 export default function LaserEyesProvider({
@@ -131,6 +133,14 @@ export default function LaserEyesProvider({
     },
     [client]
   )
+
+  const signPsbts = useCallback(
+    async (options: LaserEyesSignPsbtsOptions): Promise<SignPsbtsResponse> => {
+      return (await client?.signPsbts?.(options)) ?? defaultMethods.signPsbts()
+    },
+    [client]
+  )
+
   const switchNetwork = useCallback(
     async (network: NetworkType) =>
       await client?.switchNetwork.call(client, network),
@@ -185,6 +195,7 @@ export default function LaserEyesProvider({
       requestAccounts,
       sendBTC,
       signPsbt,
+      signPsbts,
       switchNetwork,
       inscribe,
       send,
@@ -208,6 +219,7 @@ export default function LaserEyesProvider({
     sendInscriptions,
     signMessage,
     signPsbt,
+    signPsbts,
     switchNetwork,
     getUtxos,
   ])

--- a/packages/lasereyes-react/src/providers/types.ts
+++ b/packages/lasereyes-react/src/providers/types.ts
@@ -6,6 +6,8 @@ import {
   SignMessageOptions,
   LaserEyesClient,
   MempoolUtxo,
+  LaserEyesSignPsbtsOptions,
+  SignPsbtsResponse,
 } from '@omnisat/lasereyes-core'
 
 export type LaserEyesContextType = {
@@ -51,12 +53,16 @@ export type LaserEyesContextType = {
     toSignAddressOrOptions?: string | SignMessageOptions
   ) => Promise<string>
   signPsbt: LaserEyesClient['signPsbt']
+  signPsbts: (options: LaserEyesSignPsbtsOptions) => Promise<SignPsbtsResponse>
   pushPsbt: (tx: string) => Promise<string | undefined>
   inscribe: (
     contentBase64: string,
     mimeType: ContentType
   ) => Promise<string | string[]>
   send: LaserEyesClient['send']
-  sendInscriptions: (inscriptionIds: string[], toAddress: string) => Promise<string>
+  sendInscriptions: (
+    inscriptionIds: string[],
+    toAddress: string
+  ) => Promise<string>
   getUtxos: (address: string) => Promise<MempoolUtxo[]>
 }


### PR DESCRIPTION
Currently only added oyl and unisat, others default to running signPsbt in a loop for compatibility 