### PR TITLE
fix: add requestAccounts for Orange as it for now it returns []

### DIFF
--- a/packages/lasereyes-core/src/client/providers/orange.ts
+++ b/packages/lasereyes-core/src/client/providers/orange.ts
@@ -157,6 +157,11 @@ export default class OrangeProvider extends WalletProvider {
           this.$store.setKey('provider', ORANGE)
           this.$store.setKey('address', foundAddress.address)
           this.$store.setKey('paymentAddress', foundPaymentAddress.address)
+
+          this.$store.setKey('accounts', [
+            foundAddress.address,
+            foundPaymentAddress.address,
+          ])
         }
 
         this.$store.setKey('publicKey', String(foundAddress.publicKey))


### PR DESCRIPTION
Executing requestAccounts on Orange always return an empty array.